### PR TITLE
Add pixel style and dark mode toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,9 +1,26 @@
+:root {
+  --bg-color: #fdfdfd;
+  --text-color: #222;
+  --header-bg: #fff;
+  --border-color: #eee;
+  --card-bg: #fff;
+}
+
 body {
   font-family: 'Inter', sans-serif;
-  background: #fdfdfd;
-  color: #222;
+  background: var(--bg-color);
+  color: var(--text-color);
   margin: 0;
   padding: 0;
+  transition: background 0.3s, color 0.3s;
+}
+
+body.dark {
+  --bg-color: #1d1e20;
+  --text-color: #eaeaea;
+  --header-bg: #2b2d31;
+  --border-color: #555;
+  --card-bg: #2b2d31;
 }
 
 .header {
@@ -11,8 +28,8 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background: #fff;
-  border-bottom: 2px solid #eee;
+  background: var(--header-bg);
+  border-bottom: 2px solid var(--border-color);
 }
 
 .logo {
@@ -20,11 +37,19 @@ body {
   align-items: center;
   font-weight: 700;
   font-size: 1.5rem;
+  font-family: 'Press Start 2P', cursive;
 }
 
 .logo-icon {
   margin-right: 10px;
   font-size: 32px;
+  image-rendering: pixelated;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .nav button {
@@ -34,11 +59,31 @@ body {
   cursor: pointer;
 }
 
+h1, h2 {
+  font-family: 'Press Start 2P', cursive;
+}
+
+.theme-toggle {
+  font-size: 1.2rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+}
+
+.btn {
+  background-color: var(--text-color);
+  color: var(--bg-color);
+  border: 2px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
 .dropdown {
   position: absolute;
-  background: white;
+  background: var(--card-bg);
   list-style: none;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   margin-top: 10px;
   padding: 0;
   right: 2rem;
@@ -47,12 +92,12 @@ body {
 
 .dropdown li {
   padding: 0.5rem 1rem;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .dropdown li a {
   text-decoration: none;
-  color: #222;
+  color: var(--text-color);
 }
 
 .hidden {
@@ -67,8 +112,8 @@ body {
 
 .card {
   display: flex;
-  background: #fff;
-  border: 1px solid #ddd;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
   padding: 1rem;
   margin-bottom: 1.5rem;
   align-items: center;
@@ -78,6 +123,7 @@ body {
 .card .icon {
   font-size: 48px;
   margin-right: 1.2rem;
+  image-rendering: pixelated;
 }
 
 .card h2 {
@@ -102,4 +148,5 @@ body {
   font-size: 64px;
   display: block;
   margin-bottom: 0.5rem;
+  image-rendering: pixelated;
 }

--- a/future.html
+++ b/future.html
@@ -6,6 +6,7 @@
   <title>Future Directions - TaskBeacon</title>
   <link rel="stylesheet" href="css/style.css"/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"/>
 </head>
 <body>
   <header class="header">
@@ -13,15 +14,18 @@
       <span class="logo-icon" role="img" aria-label="Beacon">📡</span>
       <span>TaskBeacon</span>
     </div>
-    <nav class="nav">
-      <button id="menu-button">Menu ▾</button>
-      <ul class="dropdown hidden" id="dropdown-menu">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="taps.html">TAPS</a></li>
-        <li><a href="psyflow.html">PsyFlow</a></li>
-        <li><a href="tasks.html">Tasks</a></li>
-      </ul>
-    </nav>
+    <div class="header-actions">
+      <nav class="nav">
+        <button id="menu-button">Menu ▾</button>
+        <ul class="dropdown hidden" id="dropdown-menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="taps.html">TAPS</a></li>
+          <li><a href="psyflow.html">PsyFlow</a></li>
+          <li><a href="tasks.html">Tasks</a></li>
+        </ul>
+      </nav>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
   </header>
 
   <main class="container">
@@ -30,5 +34,6 @@
   </main>
 
   <script src="js/menu.js"></script>
+  <script src="js/theme.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,15 +17,18 @@
       <span class="logo-icon" role="img" aria-label="Beacon">📡</span>
       <span>TaskBeacon</span>
     </div>
-    <nav class="nav">
-      <button id="menu-button">Menu ▾</button>
-      <ul class="dropdown hidden" id="dropdown-menu">
-        <li><a href="taps.html">TAPS</a></li>
-        <li><a href="psyflow.html">PsyFlow</a></li>
-        <li><a href="tasks.html">Tasks</a></li>
-        <li><a href="future.html">Future Directions</a></li>
-      </ul>
-    </nav>
+    <div class="header-actions">
+      <nav class="nav">
+        <button id="menu-button">Menu ▾</button>
+        <ul class="dropdown hidden" id="dropdown-menu">
+          <li><a href="taps.html">TAPS</a></li>
+          <li><a href="psyflow.html">PsyFlow</a></li>
+          <li><a href="tasks.html">Tasks</a></li>
+          <li><a href="future.html">Future Directions</a></li>
+        </ul>
+      </nav>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
   </header>
 
   <main class="container">
@@ -99,6 +102,7 @@
 
   <!-- Scripts -->
   <script src="js/menu.js"></script>
+  <script src="js/theme.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/showdown@2.1.0/dist/showdown.min.js"></script>
   <script>
     const converter = new showdown.Converter();

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,13 @@
+const toggle = document.getElementById('theme-toggle');
+if (toggle) {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark') {
+    document.body.classList.add('dark');
+    toggle.textContent = '☀️';
+  }
+  toggle.addEventListener('click', () => {
+    const isDark = document.body.classList.toggle('dark');
+    toggle.textContent = isDark ? '☀️' : '🌙';
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  });
+}

--- a/psyflow.html
+++ b/psyflow.html
@@ -6,6 +6,7 @@
   <title>PsyFlow - TaskBeacon</title>
   <link rel="stylesheet" href="css/style.css"/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"/>
 </head>
 <body>
   <header class="header">
@@ -13,15 +14,18 @@
       <span class="logo-icon" role="img" aria-label="Beacon">📡</span>
       <span>TaskBeacon</span>
     </div>
-    <nav class="nav">
-      <button id="menu-button">Menu ▾</button>
-      <ul class="dropdown hidden" id="dropdown-menu">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="taps.html">TAPS</a></li>
-        <li><a href="tasks.html">Tasks</a></li>
-        <li><a href="future.html">Future Directions</a></li>
-      </ul>
-    </nav>
+    <div class="header-actions">
+      <nav class="nav">
+        <button id="menu-button">Menu ▾</button>
+        <ul class="dropdown hidden" id="dropdown-menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="taps.html">TAPS</a></li>
+          <li><a href="tasks.html">Tasks</a></li>
+          <li><a href="future.html">Future Directions</a></li>
+        </ul>
+      </nav>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
   </header>
 
   <main class="container">
@@ -30,5 +34,6 @@
   </main>
 
   <script src="js/menu.js"></script>
+  <script src="js/theme.js"></script>
 </body>
 </html>

--- a/taps.html
+++ b/taps.html
@@ -6,6 +6,7 @@
   <title>TAPS - TaskBeacon</title>
   <link rel="stylesheet" href="css/style.css"/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"/>
 </head>
 <body>
   <header class="header">
@@ -13,15 +14,18 @@
       <span class="logo-icon" role="img" aria-label="Beacon">📡</span>
       <span>TaskBeacon</span>
     </div>
-    <nav class="nav">
-      <button id="menu-button">Menu ▾</button>
-      <ul class="dropdown hidden" id="dropdown-menu">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="psyflow.html">PsyFlow</a></li>
-        <li><a href="tasks.html">Tasks</a></li>
-        <li><a href="future.html">Future Directions</a></li>
-      </ul>
-    </nav>
+    <div class="header-actions">
+      <nav class="nav">
+        <button id="menu-button">Menu ▾</button>
+        <ul class="dropdown hidden" id="dropdown-menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="psyflow.html">PsyFlow</a></li>
+          <li><a href="tasks.html">Tasks</a></li>
+          <li><a href="future.html">Future Directions</a></li>
+        </ul>
+      </nav>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
   </header>
 
   <main class="container">
@@ -30,5 +34,6 @@
   </main>
 
   <script src="js/menu.js"></script>
+  <script src="js/theme.js"></script>
 </body>
 </html>

--- a/tasks.html
+++ b/tasks.html
@@ -6,6 +6,7 @@
   <title>Tasks - TaskBeacon</title>
   <link rel="stylesheet" href="css/style.css"/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"/>
 </head>
 <body>
   <header class="header">
@@ -13,15 +14,18 @@
       <span class="logo-icon" role="img" aria-label="Beacon">📡</span>
       <span>TaskBeacon</span>
     </div>
-    <nav class="nav">
-      <button id="menu-button">Menu ▾</button>
-      <ul class="dropdown hidden" id="dropdown-menu">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="taps.html">TAPS</a></li>
-        <li><a href="psyflow.html">PsyFlow</a></li>
-        <li><a href="future.html">Future Directions</a></li>
-      </ul>
-    </nav>
+    <div class="header-actions">
+      <nav class="nav">
+        <button id="menu-button">Menu ▾</button>
+        <ul class="dropdown hidden" id="dropdown-menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="taps.html">TAPS</a></li>
+          <li><a href="psyflow.html">PsyFlow</a></li>
+          <li><a href="future.html">Future Directions</a></li>
+        </ul>
+      </nav>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
   </header>
 
   <main class="container">
@@ -30,6 +34,7 @@
   </main>
 
   <script src="js/menu.js"></script>
+  <script src="js/theme.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/showdown@2.1.0/dist/showdown.min.js"></script>
   <script>
     const converter = new showdown.Converter();


### PR DESCRIPTION
## Summary
- apply pixel-style fonts and icons
- introduce light/dark theme variables
- add theme toggle button and persistence
- update all pages with new header actions

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684aba3e689c8324b378c9d82258671a